### PR TITLE
Fixed syntax for sendSDKMessage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Send data to your own application by using the Furioos SDK.
 ```javascript
 const data = { test: "test" }
 // The JSON will be sent to your application and you need to implement its interpretation
-player.sendSDKMessage(function(data); 
+player.sendSDKMessage(data); 
 ```
 
 ## SDK Local Test Example (Coming soon !)


### PR DESCRIPTION
Fixed a syntax issue.

Double checked that it shouldn't take a function as argument, and confirmed: 

```
sendSDKMessage(data) {
    if (!this.loaded) {
      return; // Not loaded.
    } 
    
    this.embed.contentWindow.postMessage({ 
      type: _eventNames.SEND_SDK_MESSAGE,
      value: data,
    }, _furioosServerUrl);
  }
```